### PR TITLE
fix(release): Do not use yarn exec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn exec "npm version ${{ needs.version.outputs.result }} --git-tag-version=false"
+      - run: npm version ${{ needs.version.outputs.result }} --git-tag-version=false
 
       - run: npm config set "//npm.pkg.github.com/:_authToken" "\${NPM_AUTH_TOKEN}" --location=project
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Yarn exec was not playing nice with the command we need to run to set the semver in package.json for publishing.
#### Additional comments?:
